### PR TITLE
Fix unchecked buf.ReadFrom error in auth0 provider

### DIFF
--- a/providers/auth0/auth0.go
+++ b/providers/auth0/auth0.go
@@ -3,7 +3,6 @@
 package auth0
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -143,18 +142,18 @@ func newConfig(provider *Provider, scopes []string) *oauth2.Config {
 }
 
 func userFromReader(r io.Reader, user *goth.User) error {
-	var rawData map[string]interface{}
-
-	buf := new(bytes.Buffer)
-	buf.ReadFrom(r)
-	err := json.Unmarshal(buf.Bytes(), &rawData)
+	data, err := io.ReadAll(r)
 	if err != nil {
+		return fmt.Errorf("failed to read user data: %w", err)
+	}
+
+	var rawData map[string]interface{}
+	if err := json.Unmarshal(data, &rawData); err != nil {
 		return err
 	}
 
 	u := auth0UserResp{}
-	err = json.Unmarshal(buf.Bytes(), &u)
-	if err != nil {
+	if err := json.Unmarshal(data, &u); err != nil {
 		return err
 	}
 	user.Email = u.Email


### PR DESCRIPTION
## Summary
Replace `bytes.Buffer` + `buf.ReadFrom()` pattern with `io.ReadAll()` to properly handle read errors.

## Problem
The `userFromReader` function used `buf.ReadFrom(r)` without checking its error return. If reading from the HTTP response body failed, the error was silently ignored, and the subsequent JSON unmarshal would fail with a confusing error message.

## Changes
- Replace `bytes.Buffer` + `buf.ReadFrom()` with `io.ReadAll()`
- Add proper error handling with descriptive wrapped error message
- Simplify code by removing unnecessary buffer allocation

## Test plan
- [x] All existing tests pass
- [x] golangci-lint passes with no issues

Fixes #7