### PR TITLE
fix: prevent panics from unchecked type assertions in OIDC provider

### DIFF
--- a/providers/openidConnect/openidConnect.go
+++ b/providers/openidConnect/openidConnect.go
@@ -383,10 +383,16 @@ func (p *Provider) validateClaims(claims map[string]interface{}) (time.Time, err
 		return time.Time{}, errors.New("issuer in token does not match issuer in OpenIDConfig discovery")
 	}
 
-	// expiry is required for JWT, not for UserInfoResponse
-	// is actually a int64, so force it in to that type
-	expiryClaim := int64(claims[expiryClaim].(float64))
-	expiry := time.Unix(expiryClaim, 0)
+	// expiry is required for JWT
+	expiryVal, ok := claims[expiryClaim]
+	if !ok {
+		return time.Time{}, errors.New("missing required exp claim in token")
+	}
+	expiryFloat, ok := expiryVal.(float64)
+	if !ok {
+		return time.Time{}, errors.New("invalid exp claim type in token")
+	}
+	expiry := time.Unix(int64(expiryFloat), 0)
 	if expiry.Add(clockSkew).Before(time.Now()) {
 		return time.Time{}, errors.New("user info JWT token is expired")
 	}
@@ -442,7 +448,10 @@ func (p *Provider) getUserInfo(accessToken string, claims map[string]interface{}
 
 // fetch and decode JSON from the given UserInfo URL
 func (p *Provider) fetchUserInfo(url, accessToken string) (map[string]interface{}, error) {
-	req, _ := http.NewRequest("GET", url, nil)
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create userinfo request: %w", err)
+	}
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", accessToken))
 
 	resp, err := p.Client().Do(req)

--- a/providers/openidConnect/openidConnect_test.go
+++ b/providers/openidConnect/openidConnect_test.go
@@ -231,6 +231,35 @@ func Test_GetOpenIDConfig_RejectsOversizedResponse(t *testing.T) {
 	a.ErrorContains(err, "http: request body too large")
 }
 
+func Test_ValidateClaims_MissingExp(t *testing.T) {
+	t.Parallel()
+	a := assert.New(t)
+
+	provider := openidConnectProvider()
+
+	claims := map[string]interface{}{
+		"aud": os.Getenv("OPENID_CONNECT_KEY"),
+		"iss": "https://accounts.google.com",
+	}
+	_, err := provider.validateClaims(claims)
+	a.EqualError(err, "missing required exp claim in token")
+}
+
+func Test_ValidateClaims_InvalidExpType(t *testing.T) {
+	t.Parallel()
+	a := assert.New(t)
+
+	provider := openidConnectProvider()
+
+	claims := map[string]interface{}{
+		"aud": os.Getenv("OPENID_CONNECT_KEY"),
+		"iss": "https://accounts.google.com",
+		"exp": "not-a-number",
+	}
+	_, err := provider.validateClaims(claims)
+	a.EqualError(err, "invalid exp claim type in token")
+}
+
 func openidConnectProvider() *Provider {
 	provider, _ := New(os.Getenv("OPENID_CONNECT_KEY"), os.Getenv("OPENID_CONNECT_SECRET"), "http://localhost/foo", server.URL)
 	return provider

--- a/providers/openidConnect/session.go
+++ b/providers/openidConnect/session.go
@@ -62,7 +62,9 @@ func (s *Session) Authorize(provider goth.Provider, params goth.Params) (string,
 	s.RefreshToken = token.RefreshToken
 	s.ExpiresAt = token.Expiry
 	if idToken := token.Extra("id_token"); idToken != nil {
-		s.IDToken = idToken.(string)
+		if str, ok := idToken.(string); ok {
+			s.IDToken = str
+		}
 	}
 	return token.AccessToken, err
 }


### PR DESCRIPTION
## Summary
- Use checked type assertions (comma-ok pattern) for `id_token` extra field to prevent panic on non-string values
- Validate `exp` claim presence and type before casting to prevent panic on malformed JWTs
- Handle `http.NewRequest` error in `fetchUserInfo` instead of discarding it

**Security impact:** Malformed provider responses could crash the server via nil pointer panics. These are now handled gracefully with error returns.

## Test plan
- [ ] `go test ./providers/openidConnect/... -v` passes
- [ ] New `Test_ValidateClaims_MissingExp` verifies missing exp returns error
- [ ] New `Test_ValidateClaims_InvalidExpType` verifies non-numeric exp returns error