### PR TITLE
fix: preserve ID token claims over UserInfo response claims

### DIFF
--- a/providers/openidConnect/openidConnect.go
+++ b/providers/openidConnect/openidConnect.go
@@ -438,9 +438,13 @@ func (p *Provider) getUserInfo(accessToken string, claims map[string]interface{}
 		return fmt.Errorf("userinfo 'sub' claim (%s) did not match id_token 'sub' claim (%s)", userInfoSubject, subject)
 	}
 
-	// Merge in userinfo claims in case id_token claims contained some that userinfo did not
+	// Merge in userinfo claims, but do not overwrite claims already present
+	// in the ID token. ID token claims are signed and should take precedence
+	// over unsigned UserInfo response claims.
 	for k, v := range userInfoClaims {
-		claims[k] = v
+		if _, exists := claims[k]; !exists {
+			claims[k] = v
+		}
 	}
 
 	return nil

--- a/providers/openidConnect/openidConnect_test.go
+++ b/providers/openidConnect/openidConnect_test.go
@@ -260,6 +260,39 @@ func Test_ValidateClaims_InvalidExpType(t *testing.T) {
 	a.EqualError(err, "invalid exp claim type in token")
 }
 
+func Test_GetUserInfo_PreservesIDTokenClaims(t *testing.T) {
+	t.Parallel()
+	a := assert.New(t)
+
+	// Mock UserInfo endpoint that returns claims that differ from the ID token
+	userInfoServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprintln(w, `{"sub":"user123","email":"eve@evil.com","picture":"https://pic.url"}`)
+	}))
+	defer userInfoServer.Close()
+
+	provider, err := NewCustomisedURL(
+		"client_id", "client_secret", "http://localhost/callback",
+		"https://example.com/auth", "https://example.com/token",
+		"https://example.com", userInfoServer.URL, "",
+	)
+	a.NoError(err)
+
+	// Simulate ID token claims with email already set
+	claims := map[string]interface{}{
+		"sub":   "user123",
+		"email": "alice@idp.com",
+	}
+
+	err = provider.getUserInfo("fake-access-token", claims)
+	a.NoError(err)
+
+	// ID token email should be preserved, not overwritten by UserInfo
+	a.Equal("alice@idp.com", claims["email"])
+	// But new claims from UserInfo should be added
+	a.Equal("https://pic.url", claims["picture"])
+}
+
 func openidConnectProvider() *Provider {
 	provider, _ := New(os.Getenv("OPENID_CONNECT_KEY"), os.Getenv("OPENID_CONNECT_SECRET"), "http://localhost/foo", server.URL)
 	return provider


### PR DESCRIPTION
## Summary
- Change UserInfo claim merge to only add claims not already present in the ID token
- ID token claims (cryptographically signed) now take precedence over UserInfo claims (unsigned)

**Security impact:** Previously, a compromised UserInfo endpoint could overwrite signed ID token claims (e.g., email), allowing identity spoofing while the `sub` claim still matched.

## Test plan
- [ ] `go test ./providers/openidConnect/... -v` passes
- [ ] New `Test_GetUserInfo_PreservesIDTokenClaims` verifies ID token email is preserved when UserInfo returns a different email, and new claims from UserInfo are still added

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed OpenID Connect merge logic so existing ID token claims are preserved and not overwritten by UserInfo data.

* **Tests**
  * Added test coverage to verify ID token claims remain intact while new UserInfo fields are merged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->